### PR TITLE
UX: set tag box display to inline-block

### DIFF
--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -34,11 +34,13 @@
       padding: 1em;
       border: 1px solid var(--primary-low);
       background: var(--primary-very-low);
+      border-radius: 2px;
       a {
-        display: block;
+        display: inline-block;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
+        margin-bottom: 4px;
       }
     }
     tbody {


### PR DESCRIPTION
Before:

<img width="277" alt="Screenshot 2021-06-24 at 20 06 41" src="https://user-images.githubusercontent.com/11170663/123282281-fa9d8480-d527-11eb-891a-387ea782b4bd.png">

After:

<img width="272" alt="Screenshot 2021-06-24 at 20 05 12" src="https://user-images.githubusercontent.com/11170663/123282303-fec9a200-d527-11eb-8a66-4e18882b4b31.png">
